### PR TITLE
:sparkles:feat: 반응형 초기 세팅 #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.7.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-responsive": "^10.0.0",
         "react-router-dom": "^6.26.0",
         "styled-components": "^6.1.12"
       },
@@ -1385,6 +1386,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q=="
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -2425,6 +2431,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2992,6 +3003,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/matchmediaquery": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+      "integrity": "sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3062,7 +3081,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3316,7 +3334,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3383,8 +3400,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -3393,6 +3409,23 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-responsive": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.0.tgz",
+      "integrity": "sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.4.2",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-router": {
@@ -3638,6 +3671,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/shallow-equal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.7.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-responsive": "^10.0.0",
     "react-router-dom": "^6.26.0",
     "styled-components": "^6.1.12"
   },

--- a/src/hooks/useMediaQueries.jsx
+++ b/src/hooks/useMediaQueries.jsx
@@ -1,0 +1,17 @@
+//breakpoint에 따른 화면 설정 위한 hook
+
+import { useMediaQuery } from "react-responsive";
+
+const useMediaQueries = () => {
+  const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
+  const isTablet = useMediaQuery({
+    query: "(min-width: 769px) and (max-width: 1023px)",
+  });
+  const isDesktop = useMediaQuery({
+    query: "(min-width: 1024px) ",
+  });
+
+  return { isMobile, isTablet, isDesktop };
+};
+
+export default useMediaQueries;

--- a/src/layouts/Header.jsx
+++ b/src/layouts/Header.jsx
@@ -1,15 +1,33 @@
 import React from "react";
 import styled from "styled-components";
+import useMediaQueries from "../hooks/useMediaQueries";
 
+//반응형 활용 예시 코드
+//추후 피그마 보고 수정할 것
 const Wrapper = styled.div`
   width: 100%;
-  background-color: #ffe6ea;
+  background-color: ${(props) =>
+    props.isMobile ? "#ffe6ea" : props.isTablet ? "#f0e6ea" : "#d3c0e0"};
   display: flex;
   justify-content: center;
+  align-items: center;
+  padding: ${(props) =>
+    props.isMobile ? "10px" : props.isTablet ? "15px" : "20px"};
 `;
 
 const Header = () => {
-  return <Wrapper>Header</Wrapper>;
+  const { isMobile, isTablet, isDesktop } = useMediaQueries();
+
+  return (
+    //Wrapper 컴포넌트에 isMobile, isTablet, isDesktop 값을 props로 전달
+    //주의: props 할때 dom문제로 인해 props하는 앞에 "$"를 쓰지 않으면 콘솔에 error 뜸!
+    //밑 코드의 $isMobile 처럼 "$" 붙이기!
+    <Wrapper $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+      {isMobile && <span>Mobile Header</span>}
+      {isTablet && <span>Tablet Header</span>}
+      {isDesktop && <span>Desktop Header</span>}
+    </Wrapper>
+  );
 };
 
 export default Header;


### PR DESCRIPTION
- breakpoint에 따른 반응형 초기 세팅을 진행했습니다.
- react-responsive 라이브러리 설치했으니 참고해주세요! (npm i react-responsive)

<img width="1141" alt="스크린샷 2024-08-18 오전 5 28 19" src="https://github.com/user-attachments/assets/5d1c6d82-cbd6-4c4a-ad21-d7c93d7aed89">

src-hooks-useMediaQueries.jsx를 생성했고, breakpoint(moblie, desktop, tablet)에 따른 width를 구현해 다른 컴포넌트에서 import할 수 있습니다. 

예시는 src-layouts-Header.jsx를 참고하면 됩니다.

<img width="1141" alt="스크린샷 2024-08-18 오전 5 30 14" src="https://github.com/user-attachments/assets/0befc59f-f904-4c40-bb7f-694d608d58a3">
