### PR TITLE
✨ feat: 디테일 페이지 라우터 연결 #2

### DIFF
--- a/src/components/ui/MainTitle.jsx
+++ b/src/components/ui/MainTitle.jsx
@@ -5,7 +5,6 @@ import useMediaQueries from "../../hooks/useMediaQueries";
 const Wrapper = styled.div`
   display: flex;
   width: 100vw;
-  /* 프롭스 */
   height: ${(props) =>
     props.isMobile ? "100px" : props.isTablet ? "180px" : "280px"};
   padding: ${(props) => "0px 20px"};

--- a/src/pages/About/index.jsx
+++ b/src/pages/About/index.jsx
@@ -1,7 +1,13 @@
 import React from "react";
+import MainTitle from "../../components/ui/MainTitle";
+import { ContentWrapper } from "../../style/commonStyle";
 
 const index = () => {
-  return <div>영캠프 소개</div>;
+  return (
+    <ContentWrapper>
+      <MainTitle title="영캠프 안내" />
+    </ContentWrapper>
+  );
 };
 
 export default index;

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -1,7 +1,13 @@
 import React from "react";
+import MainTitle from "../../components/ui/MainTitle";
+import { ContentWrapper } from "../../style/commonStyle";
 
 const index = () => {
-  return <div>FAQ</div>;
+  return (
+    <ContentWrapper>
+      <MainTitle title="FAQ" />
+    </ContentWrapper>
+  );
 };
 
 export default index;

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,7 +1,13 @@
 import React from "react";
+import MainTitle from "../../components/ui/MainTitle";
+import { ContentWrapper } from "../../style/commonStyle";
 
 const index = () => {
-  return <div>홈 페이지</div>;
+  return (
+    <ContentWrapper>
+      <MainTitle title="홈페이지" />
+    </ContentWrapper>
+  );
 };
 
 export default index;

--- a/src/pages/Location/index.jsx
+++ b/src/pages/Location/index.jsx
@@ -1,7 +1,13 @@
 import React from "react";
+import MainTitle from "../../components/ui/MainTitle";
+import { ContentWrapper } from "../../style/commonStyle";
 
 const index = () => {
-  return <div>장소 안내 페이지</div>;
+  return (
+    <ContentWrapper>
+      <MainTitle title="장소안내" />
+    </ContentWrapper>
+  );
 };
 
 export default index;

--- a/src/pages/Notification/detail/index.jsx
+++ b/src/pages/Notification/detail/index.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import MainTitle from "../../../components/ui/MainTitle";
+import { ContentWrapper } from "../../../style/commonStyle";
+import { useParams } from "react-router-dom";
+
+const index = () => {
+  const { id } = useParams();
+
+  return (
+    <ContentWrapper>
+      <MainTitle title="공지 디테일" />
+      <div>{id}번째 페이지</div>
+    </ContentWrapper>
+  );
+};
+
+export default index;

--- a/src/pages/Notification/index.jsx
+++ b/src/pages/Notification/index.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const index = () => {
-  return <div>공지</div>;
-};
-
-export default index;

--- a/src/pages/Notification/main/index.jsx
+++ b/src/pages/Notification/main/index.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import MainTitle from "../../../components/ui/MainTitle";
+import { ContentWrapper } from "../../../style/commonStyle";
+import { Link } from "react-router-dom";
+
+const index = () => {
+  return (
+    <ContentWrapper>
+      <MainTitle title="공지" />
+      <Link to={"/notification/1"}>1번 디테일 페이지</Link>
+      <br />
+      <Link to={"/notification/2"}>2번 디테일 페이지</Link>
+      <br />
+      <Link to={"/notification/3"}>3번 디테일 페이지</Link>
+      <br />
+    </ContentWrapper>
+  );
+};
+
+export default index;

--- a/src/pages/Performance/A.jsx
+++ b/src/pages/Performance/A.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import * as S from "./style";
+
+const A = () => {
+  return (
+    <S.Wrapper>
+      <div>유의사항</div>
+      <S.ImgTest src="" />
+    </S.Wrapper>
+  );
+};
+
+export default A;

--- a/src/pages/Performance/B.jsx
+++ b/src/pages/Performance/B.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  background-color: green;
+  height: 100px;
+`;
+
+const B = () => {
+  return <Wrapper>B</Wrapper>;
+};
+
+export default B;

--- a/src/pages/Performance/index.jsx
+++ b/src/pages/Performance/index.jsx
@@ -1,11 +1,15 @@
 import React from "react";
 import MainTitle from "../../components/ui/MainTitle";
 import { ContentWrapper } from "../../style/commonStyle";
+import A from "./A";
+import B from "./B";
 
 const index = () => {
   return (
     <ContentWrapper>
       <MainTitle title="공연안내" />
+      <A />
+      <B />
     </ContentWrapper>
   );
 };

--- a/src/pages/Performance/style.jsx
+++ b/src/pages/Performance/style.jsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  background-color: pink;
+  padding: 100px;
+  font-size: 50px;
+`;
+export const ImgTest = styled.img`
+  border-radius: 50px;
+  width: 140px;
+`;

--- a/src/pages/Promotion/detail/index.jsx
+++ b/src/pages/Promotion/detail/index.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import MainTitle from "../../../components/ui/MainTitle";
+import { ContentWrapper } from "../../../style/commonStyle";
+import { useParams } from "react-router-dom";
+
+const index = () => {
+  const { id } = useParams();
+
+  return (
+    <ContentWrapper>
+      <MainTitle title="홍보 디테일" />
+      <div>{id}번째 페이지</div>
+    </ContentWrapper>
+  );
+};
+
+export default index;

--- a/src/pages/Promotion/index.jsx
+++ b/src/pages/Promotion/index.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const index = () => {
-  return <div>홍보</div>;
-};
-
-export default index;

--- a/src/pages/Promotion/main/index.jsx
+++ b/src/pages/Promotion/main/index.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import MainTitle from "../../../components/ui/MainTitle";
+import { ContentWrapper } from "../../../style/commonStyle";
+import { Link } from "react-router-dom";
+
+const index = () => {
+  return (
+    <ContentWrapper>
+      <MainTitle title="홍보" />
+      <Link to={"/promotion/1"}>1번 디테일 페이지</Link>
+      <br />
+      <Link to={"/promotion/2"}>2번 디테일 페이지</Link>
+      <br />
+      <Link to={"/promotion/3"}>3번 디테일 페이지</Link>
+      <br />
+    </ContentWrapper>
+  );
+};
+
+export default index;

--- a/src/pages/Review/index.jsx
+++ b/src/pages/Review/index.jsx
@@ -1,7 +1,13 @@
 import React from "react";
+import MainTitle from "../../components/ui/MainTitle";
+import { ContentWrapper } from "../../style/commonStyle";
 
 const index = () => {
-  return <div>후기</div>;
+  return (
+    <ContentWrapper>
+      <MainTitle title="후기" />
+    </ContentWrapper>
+  );
 };
 
 export default index;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -3,8 +3,10 @@ import App from "./App";
 import Home from "./pages/Home/index";
 import Location from "./pages/Location/index";
 import Performance from "./pages/Performance/index";
-import Notification from "./pages/Notification/index";
-import Promotion from "./pages/Promotion/index";
+import Notification from "./pages/Notification/main/index";
+import Promotion from "./pages/Promotion/main/index";
+import NotificationDetail from "./pages/Notification/detail/index";
+import PromotionDetail from "./pages/Promotion/detail/index";
 import FAQ from "./pages/FAQ/index";
 import Review from "./pages/Review/index";
 import About from "./pages/About/index";
@@ -26,9 +28,11 @@ const router = createBrowserRouter([
 
       // 공지 페이지
       { path: "/notification", element: <Notification /> },
+      { path: "/notification/:id", element: <NotificationDetail /> },
 
       // 홍보 페이지
       { path: "/promotion", element: <Promotion /> },
+      { path: "/promotion/:id", element: <PromotionDetail /> },
 
       // FAQ 페이지
       { path: "/FAQ", element: <FAQ /> },


### PR DESCRIPTION
## #️⃣연관된 이슈
> #2

## 📝작업 내용

> 1. 공지
> 2. 홍보
> 디테일 페이지가 포함된 위 두 개의 페이지에 대한 라우터를 업데이트 했습니다.
> 디테일 페이지에서 useParams의 예시를 포함하였으니 참고 바랍니다.
> 또한, 각 index 페이지에서 title, commonWrapper를 통일하여 적용했습니다.
> 그 하단에서 작업 시작해주시면 되겠습니다!


### 스크린샷
- 공지 메인 페이지
<img width="1139" alt="스크린샷 2024-08-18 오후 4 12 29" src="https://github.com/user-attachments/assets/f1aabdd9-47ee-4010-b984-f3d4dc1284ad">

- 공지 디테일 페이지
<img width="1139" alt="스크린샷 2024-08-18 오후 4 12 11" src="https://github.com/user-attachments/assets/e7ca6027-d9f2-47cc-b5f7-24d7831effc8">
