### PR TITLE
💄 style: About 페이지 반응형 구현

### DIFF
--- a/src/data/profileData.jsx
+++ b/src/data/profileData.jsx
@@ -1,24 +1,38 @@
 import sampleImage from '../assets/images/About/about_sample.jpg'
 
-export const leaderProfiles = [
-	{ id: 1, name: "황진경", role: "TF장", image: sampleImage },
-	{ id: 2, name: "김준범", role: "PM", image: sampleImage },
-	{ id: 3, name: "한은서", role: "Design", image: sampleImage },
-	{ id: 4, name: "설현아", role: "Frontend", image: sampleImage },
-	{ id: 5, name: "오찬주", role: "Frontend", image: sampleImage },  
-	{ id: 6, name: "김찬빈", role: "Backend", image: sampleImage }
+export const studentCommitteeProfiles = [
+	{ id: 1, name: "김OO", role: "PM", image: sampleImage },
+	{ id: 2, name: "김OO", role: "PM", image: sampleImage },
+	{ id: 3, name: "김OO", role: "PM", image: sampleImage },
+	{ id: 4, name: "김OO", role: "PM", image: sampleImage },
+	{ id: 5, name: "김OO", role: "PM", image: sampleImage },
+	{ id: 6, name: "김OO", role: "PM", image: sampleImage },
+	{ id: 7, name: "김OO", role: "PM", image: sampleImage },
+	{ id: 8, name: "김OO", role: "PM", image: sampleImage }
 ];
   
-  export const memberProfiles = [
-	{ id: 1, name: "이승협", role: "PM", image: sampleImage },
-	{ id: 2, name: "이수빈", role: "Design", image: sampleImage },
-	{ id: 3, name: "윤혜정", role: "Design", image: sampleImage },
-	{ id: 4, name: "강신지", role: "Frontend", image: sampleImage },
-	{ id: 5, name: "김수빈", role: "Frontend", image: sampleImage },
-	{ id: 6, name: "백동민", role: "Frontend", image: sampleImage },
-	{ id: 7, name: "오세인", role: "Frontend", image: sampleImage },
-	{ id: 8, name: "이민수", role: "Frontend", image: sampleImage },
-	{ id: 9, name: "이유진", role: "Frontend", image: sampleImage },
-	{ id: 10, name: "김세은", role: "Backend", image: sampleImage },
-	{ id: 11, name: "임주혁", role: "Backend", image: sampleImage }
+  export const youngCamperProfiles = [
+	{ id: 1, name: "황진경", role: "TF장", image: sampleImage },
+	{ id: 2, name: "김준범", role: "PM", image: sampleImage },
+	{ id: 3, name: "이승협", role: "PM", image: sampleImage },
+
+	// 디자인
+	{ id: 4, name: "한은서", role: "디자인", image: sampleImage },
+	{ id: 5, name: "윤혜정", role: "디자인", image: sampleImage },
+	{ id: 6, name: "이수빈", role: "디자인", image: sampleImage },
+	
+	// 백엔드
+	{ id: 7, name: "김세은", role: "백엔드", image: sampleImage },
+	{ id: 8, name: "김찬빈", role: "백엔드", image: sampleImage },
+	{ id: 9, name: "임주혁", role: "백엔드", image: sampleImage },
+
+	// 프론트엔드
+	{ id: 10, name: "강신지", role: "프론트엔드", image: sampleImage },
+	{ id: 11, name: "김수빈", role: "프론트엔드", image: sampleImage },
+	{ id: 12, name: "백동민", role: "프론트엔드", image: sampleImage },
+	{ id: 13, name: "설현아", role: "프론트엔드", image: sampleImage },
+	{ id: 14, name: "오세인", role: "프론트엔드", image: sampleImage },
+	{ id: 15, name: "오찬주", role: "프론트엔드", image: sampleImage },
+	{ id: 16, name: "이민수", role: "프론트엔드", image: sampleImage },
+	{ id: 17, name: "이유진", role: "프론트엔드", image: sampleImage }
   ];

--- a/src/pages/About/Category.jsx
+++ b/src/pages/About/Category.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import * as S from "./style";
+import useMediaQueries from "../../hooks/useMediaQueries";
 
 const Category = ({ children }) => {
-  return <S.Category>{children}</S.Category>;
+  const { isDesktop } = useMediaQueries();
+
+  return <S.Category $isDesktop={isDesktop}>{children}</S.Category>;
 };
 
 export default Category;

--- a/src/pages/About/ProfileList.jsx
+++ b/src/pages/About/ProfileList.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ProfileCard from './ProfileCard';
 import * as S from "./style";
+import useMediaQueries from "../../hooks/useMediaQueries";
 
 const ProfileList = ({ profiles }) => {
+  const { isDesktop } = useMediaQueries();
+
   return (
-    <S.ProfileListWrapper>
+    <S.ProfileListWrapper $isDesktop={isDesktop}>
       {profiles.map(profile => (
         <ProfileCard key={profile.id} profile={profile} />
       ))}

--- a/src/pages/About/Section.jsx
+++ b/src/pages/About/Section.jsx
@@ -2,15 +2,19 @@ import React from 'react';
 import Category from './Category';
 import ProfileList from './ProfileList';
 import * as S from "./style";
+import useMediaQueries from "../../hooks/useMediaQueries";
+
 
 const Section = ({ title, subtitle, profiles }) => {
+  const { isMobile, isTablet, isDesktop } = useMediaQueries();
+
   return (
     <>
-    <S.SectionWrapper>
+    <S.SectionWrapper $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
       <Category>{title}</Category>
-      <S.Subtitle>{subtitle}</S.Subtitle>
+      <S.Subtitle $isDesktop={isDesktop}>{subtitle}</S.Subtitle>
     </S.SectionWrapper>
-    <ProfileList profiles={profiles} />
+    <ProfileList $isDesktop={isDesktop} profiles={profiles} />
     </>
   );
 };

--- a/src/pages/About/Section.jsx
+++ b/src/pages/About/Section.jsx
@@ -3,12 +3,15 @@ import Category from './Category';
 import ProfileList from './ProfileList';
 import * as S from "./style";
 
-const Section = ({ title, profiles }) => {
+const Section = ({ title, subtitle, profiles }) => {
   return (
+    <>
     <S.SectionWrapper>
       <Category>{title}</Category>
-      <ProfileList profiles={profiles} />
+      <S.Subtitle>{subtitle}</S.Subtitle>
     </S.SectionWrapper>
+    <ProfileList profiles={profiles} />
+    </>
   );
 };
 

--- a/src/pages/About/index.jsx
+++ b/src/pages/About/index.jsx
@@ -1,18 +1,77 @@
-import React from "react";
+import React, { useState } from "react";
 import MainTitle from "../../components/ui/MainTitle";
 import { ContentWrapper } from "../../style/commonStyle";
 import Section from "./Section";
-import { leaderProfiles, memberProfiles } from "../../data/profileData";
-
+import { studentCommitteeProfiles, youngCamperProfiles } from "../../data/profileData";
+import * as S from "./style";
+import useMediaQueries from "../../hooks/useMediaQueries";
 
 const index = () => {
+  const [activeTab, setActiveTab] = useState('students'); // 초기 활성 탭 설정
+  const { isMobile, isTablet, isDesktop } = useMediaQueries();
+
+  // 탭에 따라 프로필 데이터를 선택
+  const profilesToDisplay = activeTab === 'students' 
+    ? studentCommitteeProfiles 
+    : youngCamperProfiles;
+
+  // 소개글 변경될 수 있어 구분해둠
+  const subtitle = activeTab === 'students' 
+  ? "영캠프는 대한민국 대학 불교 동아리들이 연합하여 주최하는 특별한 축제입니다." 
+  : "영캠프는 대한민국 대학 불교 동아리들이 연합하여 주최하는 특별한 축제입니다.";
+
+
   return (
     <>
-      <MainTitle title="영캠퍼" />
+      <MainTitle
+        mainText="기획단"
+        subText="영캠프는 대한민국 대학 불교 동아리들이 연합하여 주최하는 특별한 축제입니다."
+      />
+      {isDesktop ? (
       <ContentWrapper>
-        <Section title="Team Lead" profiles={leaderProfiles} />
-        <Section title="Team Member" profiles={memberProfiles} />
+        <S.TabBar>
+          <S.TabButton 
+            isActive={activeTab === 'students'} 
+            onClick={() => setActiveTab('students')}
+          >
+            학생 기획 위원단
+          </S.TabButton>
+          <S.TabButton 
+            isActive={activeTab === 'campers'} 
+            onClick={() => setActiveTab('campers')}
+          >
+            영캠퍼
+          </S.TabButton>
+        </S.TabBar>
+        <Section 
+          title={activeTab === 'students' ? "학생 기획 위원단" : "영캠퍼"}
+          subtitle={subtitle}
+          profiles={profilesToDisplay} 
+        />
       </ContentWrapper>
+      ) : (
+        <>
+          <S.TabBar>
+            <S.TabButton 
+              isActive={activeTab === 'students'} 
+              onClick={() => setActiveTab('students')}
+            >
+              학생 기획 위원단
+            </S.TabButton>
+            <S.TabButton 
+              isActive={activeTab === 'campers'} 
+              onClick={() => setActiveTab('campers')}
+            >
+              영캠퍼
+            </S.TabButton>
+          </S.TabBar>
+          <Section 
+            title={activeTab === 'students' ? "학생 기획 위원단" : "영캠퍼"}
+            subtitle={subtitle}
+            profiles={profilesToDisplay} 
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/pages/About/index.jsx
+++ b/src/pages/About/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import MainTitle from "../../components/ui/MainTitle";
-import { ContentWrapper } from "../../style/commonStyle";
 import Section from "./Section";
 import { studentCommitteeProfiles, youngCamperProfiles } from "../../data/profileData";
 import * as S from "./style";
@@ -8,7 +7,7 @@ import useMediaQueries from "../../hooks/useMediaQueries";
 
 const index = () => {
   const [activeTab, setActiveTab] = useState('students'); // 초기 활성 탭 설정
-  const { isMobile, isTablet, isDesktop } = useMediaQueries();
+  const { isDesktop } = useMediaQueries();
 
   // 탭에 따라 프로필 데이터를 선택
   const profilesToDisplay = activeTab === 'students' 
@@ -27,16 +26,15 @@ const index = () => {
         mainText="기획단"
         subText="영캠프는 대한민국 대학 불교 동아리들이 연합하여 주최하는 특별한 축제입니다."
       />
-      {isDesktop ? (
-      <ContentWrapper>
-        <S.TabBar>
-          <S.TabButton 
+      <S.ContentWrapper $isDesktop={isDesktop}>
+        <S.TabBar $isDesktop={isDesktop}>
+          <S.TabButton $isDesktop={isDesktop}
             isActive={activeTab === 'students'} 
             onClick={() => setActiveTab('students')}
           >
             학생 기획 위원단
           </S.TabButton>
-          <S.TabButton 
+          <S.TabButton $isDesktop={isDesktop}
             isActive={activeTab === 'campers'} 
             onClick={() => setActiveTab('campers')}
           >
@@ -48,30 +46,7 @@ const index = () => {
           subtitle={subtitle}
           profiles={profilesToDisplay} 
         />
-      </ContentWrapper>
-      ) : (
-        <>
-          <S.TabBar>
-            <S.TabButton 
-              isActive={activeTab === 'students'} 
-              onClick={() => setActiveTab('students')}
-            >
-              학생 기획 위원단
-            </S.TabButton>
-            <S.TabButton 
-              isActive={activeTab === 'campers'} 
-              onClick={() => setActiveTab('campers')}
-            >
-              영캠퍼
-            </S.TabButton>
-          </S.TabBar>
-          <Section 
-            title={activeTab === 'students' ? "학생 기획 위원단" : "영캠퍼"}
-            subtitle={subtitle}
-            profiles={profilesToDisplay} 
-          />
-        </>
-      )}
+      </S.ContentWrapper>
     </>
   );
 };

--- a/src/pages/About/style.jsx
+++ b/src/pages/About/style.jsx
@@ -1,25 +1,34 @@
 import React from 'react'
 import { styled } from "styled-components";
 
+export const ContentWrapper =styled.div`
+	padding: ${(props) => props.$isDesktop ? "0px 170px" : "0px 0px" };
+`
+
 export const TabBar = styled.div`
 	display: flex;
 	justify-content: center;
 	width: 100%;
 	max-width: 1440px;
-	padding: 83px 0px;
-	margin: 0 auto
+	padding: ${(props) => props.$isDesktop ? "83px 0px" : "0px 0px" };
+	margin: 0 auto;
+	margin-bottom: ${(props) => props.$isDesktop ? "100px" : "77px"};
 `;
 
 export const TabButton = styled.button`
 	width: 100%;
-	height: 83px;
-	font-size: 28px;
+	height: ${(props) => props.$isDesktop ? "83px" : "47px" };
+	font-family: "MonRegular";
+	font-size: ${(props) => props.$isDesktop ? "24px" : "14px" };
+	font-weight: 600;
+	line-height: 18px; /* 128.571% */
+	letter-spacing: 0.14px;
+
 	cursor: pointer;
 	border-top: 2px solid #0068FF;
 	border-bottom: 2px solid #0068FF;
 	background: ${(props) => (props.isActive ? '#0068FF' : '#fff')};
 	color: ${(props) => (props.isActive ? '#fff' : '#0068FF')};
-	font-family: "MonRegular";
 
 	transition: 
 		background 0.3s ease, 
@@ -39,29 +48,29 @@ export const SectionWrapper = styled.div`
 	display: flex;
 	width: 100%;
 	flex-direction: column;
-	padding: 48px 0px;
-	gap: 24px;
+	padding: ${(props) => props.$isMobile ? "39px 24px" : props.$isTablet ? "58px 24px" : "48px 0px" };
+	gap: ${(props) => props.$isDesktop ? "24px" : "12px" };
+	margin-bottom: ${(props) => props.$isDesktop ? "51px" : "12px"};
 `;
 
 export const Category = styled.div`
 	align-self: stretch;
 	color: #000;
 	font-family: "MonRegular";
-	font-size: 28px;
-	font-weight: 700;
-	line-height: 161.8%; /* 45.304px */
-
+	font-size: ${(props) => props.$isDesktop ? "28px" : "20px" };
+	font-weight: ${(props) => props.$isDesktop ? "700" : "600" };
+	line-height: ${(props) => props.$isDesktop ? "48px" : "24px" };
+	
 	align-items: center;
 `;
 
 export const Subtitle = styled.div`
   	color: #637D92;
 	font-family: "MonRegular";
-	font-size: 22px;
-	font-style: normal;
+	font-size: ${(props) => props.$isDesktop ? "22px" : "12px" };
 	font-weight: 400;
-	line-height: 30px; /* 136.364% */
-	letter-spacing: -0.11px;
+	line-height: ${(props) => props.$isDesktop ? "30px" : "18px" };
+	letter-spacing: ${(props) => props.$isDesktop ? "-0.11px" : "-0.06px" };
 `;
 
 export const ProfileListWrapper = styled.div`
@@ -69,6 +78,7 @@ export const ProfileListWrapper = styled.div`
 	width: 100%;
 	flex-wrap: wrap;
 	gap: 24px;
+	padding: ${(props) => props.$isDesktop ? "48px 0px" : "24px 24px" };
 
 	justify-content: center;
 	/* 피그마엔 명시되어 있지 않지만 임의로 설정해둠*/
@@ -76,7 +86,13 @@ export const ProfileListWrapper = styled.div`
 `;
 
 export const ProfileCard = styled.div`
-	width: 350px;
+	display: flex;
+	
+	min-width: 320px;
+	max-width: 450px;
+	flex-direction: column;
+	align-items: center;
+	flex: 1 0 0;
 	box-sizing: border-box;
 	border-radius: 8px;
 	

--- a/src/pages/About/style.jsx
+++ b/src/pages/About/style.jsx
@@ -1,30 +1,74 @@
 import React from 'react'
 import { styled } from "styled-components";
 
+export const TabBar = styled.div`
+	display: flex;
+	justify-content: center;
+	width: 100%;
+	max-width: 1440px;
+	padding: 83px 0px;
+	margin: 0 auto
+`;
+
+export const TabButton = styled.button`
+	width: 100%;
+	height: 83px;
+	font-size: 28px;
+	cursor: pointer;
+	border-top: 2px solid #0068FF;
+	border-bottom: 2px solid #0068FF;
+	background: ${(props) => (props.isActive ? '#0068FF' : '#fff')};
+	color: ${(props) => (props.isActive ? '#fff' : '#0068FF')};
+	font-family: "MonRegular";
+
+	transition: 
+		background 0.3s ease, 
+		color 0.3s ease, 
+		border-top 0.3s ease, 
+		border-bottom 0.3s ease;
+
+	&:hover {
+		background: ${(props) => (props.isActive ? '#0068FF' : 'linear-gradient(102deg, #0068FF, #B9FF9C)')};
+  		border-top: transparent;
+		border-bottom: transparent;
+		color: #fff;
+	}
+`;
+
 export const SectionWrapper = styled.div`
 	display: flex;
 	width: 100%;
 	flex-direction: column;
+	padding: 48px 0px;
+	gap: 24px;
 `;
 
 export const Category = styled.div`
 	align-self: stretch;
 	color: #000;
-	font-family: "Noto Sans KR";
+	font-family: "MonRegular";
 	font-size: 28px;
 	font-weight: 700;
 	line-height: 161.8%; /* 45.304px */
-	padding: 32px 20px;
-	margin-top: 48px;
 
 	align-items: center;
+`;
+
+export const Subtitle = styled.div`
+  	color: #637D92;
+	font-family: "MonRegular";
+	font-size: 22px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 30px; /* 136.364% */
+	letter-spacing: -0.11px;
 `;
 
 export const ProfileListWrapper = styled.div`
 	display: flex;
 	width: 100%;
 	flex-wrap: wrap;
-	gap: 25px;
+	gap: 24px;
 
 	justify-content: center;
 	/* 피그마엔 명시되어 있지 않지만 임의로 설정해둠*/


### PR DESCRIPTION
## #️⃣연관된 이슈
> #46 

## 📝작업 내용

> 1. 수정된 디자인에 맞게 전반적인 레이아웃을 수정하였습니다.

> 2. 디자인 수정에 따라 데스크탑 레이아웃에서 기존 ContentWrapper의 상하 100px 여백이 필요하지 않아져서 따로 스타일을 적용하였습니다.

> 3. 상단 탭바를 만들어 학생 기획 위원단과 영캠퍼를 분류하였습니다.

> 4. 이에 따라 데이터 파일도 기존 리더/멤버 -> 위원단/영캠퍼로 재분류 및 임시 데이터를 넣어 놓았습니다.

> 5. ~~프로필 카드 hover 시 그라데이션 효과를 주어야 하는데, 피그마에서 구체적인 속성값 확인이 어려워 질문 남겨 놓았고 답변 받는 즉시 반영할 계획입니다.~~
바보... 컴포넌트 있는 걸 이제 확인했습니다... 그라데이션까지 완성 후 다시 PR 하겠습니다!

### 스크린샷 (선택)
- 데스크탑
![image](https://github.com/user-attachments/assets/bd02f725-a1e9-4c11-bf79-82ce722b0fb8)

- 태블릿
![image](https://github.com/user-attachments/assets/8a6fd5a5-7bf0-423e-b755-138dbb63cde0)

- 모바일
![image](https://github.com/user-attachments/assets/52f7f97a-199a-4c27-a6ec-0d5159b065bb)


