### PR TITLE
💄 style: commonStyle, TitleSet, Banner 반응형 재설정 #4

### DIFF
--- a/src/components/ui/MainTitle.jsx
+++ b/src/components/ui/MainTitle.jsx
@@ -18,8 +18,8 @@ const Wrapper = styled.div`
 `;
 const BannerWrapper = styled.div`
   /* 가운데 정렬 */
-  margin: 0 auto;
-  /* margin: ${(props) => (props.$isDesktop ? " 0 auto" : "")}; */
+  /* margin: 0 auto; */
+  margin: ${(props) => (props.$isDesktop ? " 0 auto" : "")};
   padding: ${(props) =>
     (props.$isTablet || props.$isMobile) &&
     "0 4px"}; /* TitleSet.jsx padding: 20px => 합 24px*/

--- a/src/components/ui/MainTitle.jsx
+++ b/src/components/ui/MainTitle.jsx
@@ -15,17 +15,14 @@ const Wrapper = styled.div`
 
   opacity: var(--sds-size-stroke-border);
   background: var(--Base-Base-White, #fafafa);
-  font-size: ${(props) =>
-    props.isMobile
-      ? "20px" /* 모바일 미반영 */
-      : props.isTablet
-      ? "30px" /* 테블릿 미반영 */
-      : "40px"}; /* 데스크탑 40px */
 `;
 const BannerWrapper = styled.div`
-  /* padding: 0px 180px; */
   /* 가운데 정렬 */
-  ${(props) => (props.$isDesktop ? "margin: 0 auto;" : "padding: 0 12px;")}
+  margin: 0 auto;
+  /* margin: ${(props) => (props.$isDesktop ? " 0 auto" : "")}; */
+  padding: ${(props) =>
+    (props.$isTablet || props.$isMobile) &&
+    "0 4px"}; /* TitleSet.jsx padding: 20px => 합 24px*/
 
   display: flex;
   flex-direction: column;
@@ -40,8 +37,12 @@ const MainTitle = ({ mainText, subText }) => {
 
   return (
     <Wrapper $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
-      <BannerWrapper>
-        <TitleSet mainText={mainText} subText={subText} />
+      <BannerWrapper
+        $isMobile={isMobile}
+        $isTablet={isTablet}
+        $isDesktop={isDesktop}
+      >
+        <TitleSet mainText={mainText} subText={subText} isBanner={isDesktop} />
       </BannerWrapper>
     </Wrapper>
   );

--- a/src/components/ui/TitleSet.jsx
+++ b/src/components/ui/TitleSet.jsx
@@ -36,7 +36,10 @@ const MainText = styled.div`
   font-style: normal;
   font-weight: 800;
   line-height: normal;
-  letter-spacing: -3.04px;
+  letter-spacing: ${(props) =>
+    props.$isDesktop
+      ? "1.9px"
+      : "0.2px"}; /* 데스크탑 38px, 모바일+태블릿 20px */
 `;
 const SubText = styled.div`
   color: var(--text-grey800, #637d92);
@@ -48,7 +51,10 @@ const SubText = styled.div`
   font-style: normal;
   font-weight: 400;
   line-height: normal;
-  letter-spacing: -0.11px;
+  letter-spacing: ${(props) =>
+    props.$isDesktop
+      ? "0.4px"
+      : "0.06px"}; /* 데스크탑 38px, 모바일+태블릿 20px */
 `;
 
 const TitleSet = ({ mainText, subText, isBanner }) => {

--- a/src/components/ui/TitleSet.jsx
+++ b/src/components/ui/TitleSet.jsx
@@ -4,10 +4,10 @@ import useMediaQueries from "../../hooks/useMediaQueries";
 
 const Wrapper = styled.div`
   display: flex;
-  /* width: ${(props) => props.$isDesktop && "1100px"}; */
+  width: ${(props) => (props.$isDesktop ? "1100px" : "100%")};
   /* 반응형 */
-  width: ${(props) =>
-    props.$isDesktop ? "1100px" : props.$isTablet ? "672px" : "360px"};
+  /* width: ${(props) =>
+    props.$isDesktop ? "1100px" : props.$isTablet ? "672px" : "360px"}; */
 
   padding: ${(props) =>
     props.$isBanner

--- a/src/components/ui/TitleSet.jsx
+++ b/src/components/ui/TitleSet.jsx
@@ -4,21 +4,33 @@ import useMediaQueries from "../../hooks/useMediaQueries";
 
 const Wrapper = styled.div`
   display: flex;
-  width: ${(props) => props.$isDesktop && "1100px"};
+  /* width: ${(props) => props.$isDesktop && "1100px"}; */
+  /* 반응형 */
+  width: ${(props) =>
+    props.$isDesktop ? "1100px" : props.$isTablet ? "672px" : "360px"};
+
   padding: ${(props) =>
-    props.$isDesktop
-      ? "48px"
-      : "30px 20px"}; /* 데스크탑 48px, 모바일+태블릿 0 36px */
+    props.$isBanner
+      ? "0 48px"
+      : props.$isDesktop
+      ? "48px 0"
+      : "30px 20px"}; /* 데스크탑 48px, 모바일|태블릿 0 36px */
+
   flex-direction: column;
   align-items: flex-start;
-  gap: ${(props) =>
-    props.$isDesktop ? "24px" : "12px"}; /* 데스크탑 24px, 모바일+태블릿 12px */
+  gap: 24px;
+
+  /* 768px ~ 1150px 사이의 별도 padding 값 적용 (기존 1110일 때 좌우 padding 0) */
+  @media (min-width: 768px) and (max-width: 1150px) {
+    padding: ${(props) =>
+      props.$isBanner ? "0 68px" : props.$isDesktop ? "48px 20px" : ""};
+  }
 `;
 const MainText = styled.div`
   color: var(--text-black, #0a0b0a);
 
   /* Primary/Desktop/Hero2 */
-  font-family: Montserrat;
+  font-family: MonAExtraBold;
   font-size: ${(props) =>
     props.$isDesktop ? "38px" : "20px"}; /* 데스크탑 38px, 모바일+태블릿 20px */
   font-style: normal;
@@ -30,7 +42,7 @@ const SubText = styled.div`
   color: var(--text-grey800, #637d92);
 
   /* Primary/Desktop/Body1_regular */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) =>
     props.$isDesktop ? "22px" : "12px"}; /* 데스크탑 22px, 모바일+태블릿 12px */
   font-style: normal;
@@ -39,11 +51,11 @@ const SubText = styled.div`
   letter-spacing: -0.11px;
 `;
 
-const TitleSet = ({ mainText, subText }) => {
+const TitleSet = ({ mainText, subText, isBanner }) => {
   const { isMobile, isTablet, isDesktop } = useMediaQueries();
 
   return (
-    <Wrapper $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+    <Wrapper $isDesktop={isDesktop} $isTablet={isTablet} $isBanner={isBanner}>
       <MainText
         $isMobile={isMobile}
         $isTablet={isTablet}

--- a/src/hooks/useMediaQueries.jsx
+++ b/src/hooks/useMediaQueries.jsx
@@ -3,9 +3,9 @@
 import { useMediaQuery } from "react-responsive";
 
 const useMediaQueries = () => {
-  const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
+  const isMobile = useMediaQuery({ query: "(max-width: 767px)" });
   const isTablet = useMediaQuery({
-    query: "(min-width: 769px) and (max-width: 1023px)",
+    query: "(min-width: 768px) and (max-width: 1023px)",
   });
   const isDesktop = useMediaQuery({
     query: "(min-width: 1024px) ",

--- a/src/pages/Performance/index.jsx
+++ b/src/pages/Performance/index.jsx
@@ -22,27 +22,18 @@ const Index = () => {
         mainText="공연안내"
         subText="영캠프는 대한민국 대학 불교 동아리들이 연합하여 주최하는 특별한 축제입니다."
       />
-      {isDesktop ? (
-        <ContentWrapper>
-          <TimeTable
-            modalOpen={modalOpen}
-            setModalOpen={setModalOpen}
-            onArtistClick={handleOpenModal} // 모달 열기 핸들러 전달
-          />
-          <Attention />
-        </ContentWrapper>
-      ) : (
-        <>
-          <TimeTable
-            modalOpen={modalOpen}
-            setModalOpen={setModalOpen}
-            onArtistClick={handleOpenModal} // 모달 열기 핸들러 전달
-          />
-          <Attention />
-        </>
-      )}
-
-      {/* 모달을 항상 렌더링하고 상태로 제어 */}
+      <ContentWrapper
+        $isMobile={isMobile}
+        $isTablet={isTablet}
+        $isDesktop={isDesktop}
+      >
+        <TimeTable
+          modalOpen={modalOpen}
+          setModalOpen={setModalOpen}
+          onArtistClick={handleOpenModal} // 모달 열기 핸들러 전달
+        />
+        <Attention />
+      </ContentWrapper>
       {modalOpen && (
         <ArtistModal artist={clickedArtist} setModalOpen={setModalOpen} />
       )}

--- a/src/pages/Performance/style.jsx
+++ b/src/pages/Performance/style.jsx
@@ -6,9 +6,9 @@ export const ArtistWrapper = styled.div`
   flex-direction: column;
 `;
 export const Container = styled.div`
-  width: ${(props) =>
-    props.$isDesktop ? "1000px" : props.$isTablet ? "727px" : ""};
-  /* props.$isDesktop ? "1000px" : props.$isTablet ? "727px" : "320px"}; */
+  width: ${(props) => (props.$isDesktop ? "1000px" : "")};
+  /* width: ${(props) =>
+    props.$isDesktop ? "1000px" : props.$isTablet ? "727px" : "320px"}; */
   display: flex;
   flex-direction: column;
   margin: ${(props) => (props.$isTablet || props.$isMobile) && "0 auto"};
@@ -51,7 +51,7 @@ export const EventTime = styled.div`
     0px 3px 7px rgba(0, 0, 0, 0.12);
 
   /* Primary/Mobile/Body1 */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isDesktop ? "32px" : "18px")};
   font-style: normal;
   font-weight: 400;
@@ -60,9 +60,9 @@ export const EventTime = styled.div`
 `;
 export const EventName = styled.div`
   display: flex;
-  width: ${(props) =>
-    props.$isDesktop ? "500px" : props.$isTablet ? "637px" : "60vw"};
-  /* props.$isDesktop ? "500px" : props.$isTablet ? "637px" : "230px"}; */
+  width: ${(props) => (props.$isDesktop ? "500px" : "60vw")};
+  /* width: ${(props) =>
+    props.$isDesktop ? "500px" : props.$isTablet ? "637px" : "230px"}; */
   height: ${(props) => (props.$isDesktop || props.$isEvent ? "250px" : "90px")};
   padding: 30px;
   flex-direction: column;
@@ -71,7 +71,7 @@ export const EventName = styled.div`
   color: var(--Base-Real-White, #fff);
 
   /* Primary/Desktop/H1_regular */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isDesktop ? "32px" : "24px")};
   font-style: normal;
   font-weight: 400;
@@ -85,7 +85,7 @@ export const SmallText = styled.div`
   color: var(--new-main-white, #fafafa);
 
   /* Primary/Desktop/H1_regular */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isDesktop ? "32px" : "24px")};
   font-style: normal;
   font-weight: ${(props) => (props.$isDesktop ? "400" : "800")};
@@ -99,7 +99,7 @@ export const EventText = styled.div`
   color: var(--new-main-white, #fafafa);
 
   /* Primary/Desktop/Hero1_regular */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isDesktop ? "48px" : "28px")};
   font-style: normal;
   font-weight: 400;
@@ -140,7 +140,7 @@ export const GuideTime = styled.div`
     0px 3px 7px rgba(0, 0, 0, 0.12);
 
   /* Primary/Desktop/H1_regular */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isDesktop ? "32px" : "18px")};
   font-style: normal;
   font-weight: 400;
@@ -150,9 +150,9 @@ export const GuideTime = styled.div`
 export const GuideName = styled.div`
   display: flex;
 
-  width: ${(props) =>
-    props.$isDesktop ? "500px" : props.$isTablet ? "637px" : "60vw"};
-  /* props.$isDesktop ? "500px" : props.$isTablet ? "637px" : "230px"}; */
+  width: ${(props) => (props.$isDesktop ? "500px" : "60vw")};
+  /* width: ${(props) =>
+    props.$isDesktop ? "500px" : props.$isTablet ? "637px" : "230px"}; */
   height: ${(props) => (props.$isDesktop ? "100px" : "90px")};
 
   padding: 0 30px;
@@ -165,7 +165,7 @@ export const GuideName = styled.div`
   color: var(--Base-Real-White, #fff);
 
   /* Primary/Desktop/H1_regular */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isDesktop ? "32px" : "24px")};
   font-style: normal;
   font-weight: 400;
@@ -254,7 +254,7 @@ export const ArtistName = styled.div`
   color: var(--new-main-black, #0a0b0a);
 
   /* Primary/Desktop/H1 */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isMobile ? "24px" : "32px")};
   font-style: normal;
   font-weight: 800;
@@ -269,7 +269,7 @@ export const DetailText = styled.div`
   color: var(--new-grey-grey900, #4a5e6d);
 
   /* Primary/Desktop/Body3 */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: ${(props) => (props.$isMobile ? "12px" : "20px")};
   font-style: normal;
   font-weight: 400;
@@ -292,7 +292,7 @@ export const ModalMusic = styled.div`
   color: var(--Secondary-Secondary900, #4a5e6d);
 
   /* Primary/Desktop/Body3 */
-  font-family: Montserrat;
+  font-family: MonARegular;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;

--- a/src/style/commonStyle.js
+++ b/src/style/commonStyle.js
@@ -10,10 +10,11 @@ export const ContentWrapper = styled.div`
   margin: 0 auto;
 
   /* 반응형 */
-  max-width: ${(props)=> 
+  max-width: 1100px;
+  /* max-width: ${(props)=> 
   props.$isDesktop ? "1100px"
   : props.$isTablet ? "768px"
-  : "360px"};
+  : "360px"}; */
 
   padding: ${(props)=> 
   props.$isDesktop ? "100px 0px"

--- a/src/style/commonStyle.js
+++ b/src/style/commonStyle.js
@@ -1,16 +1,24 @@
 import styled from "styled-components";
 
-// 메인 컨텐츠의 좌,우 170px / 상,하 100px 패딩을 정의합니다.
+// PC 1100px | Tablet 672px | Mobile 360px 초과시, 좌우 마진(중앙 정렬)
 export const ContentWrapper = styled.div`
-  /* padding: 100px 170px; */
   display: flex;
-  max-width: 1100px;
-  padding: var(--XXL, 100px) var(--Spacing-0, 0px);
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  gap: 50px;
-
-  /* 가운데 정렬 */
+  
+  /* max-width 초과시, 가운데 정렬 */
   margin: 0 auto;
+
+  /* 반응형 */
+  max-width: ${(props)=> 
+  props.$isDesktop ? "1100px"
+  : props.$isTablet ? "768px"
+  : "360px"};
+
+  padding: ${(props)=> 
+  props.$isDesktop ? "100px 0px"
+  : props.$isTablet ? "48px"
+  : "50px 0"};
+
+  gap: ${(props)=> props.$isDesktop ? "100px": "50px"};
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #4, #6

## 📝작업 내용

> commonStyle, TitleSet, MainTitle 반응형 재설정 했습니다.
1. desktop 일 때, 1440px 초과시, 중앙 정렬
2. 그 외, 피그마의 padding 값에 따름

> ContentWrapper 반응형을 다음과 같이 설정하였습니다. props로 isDesktop, isTablet을 설정해주시면 감사하겠습니다!
```
  padding: ${(props)=> 
  props.$isDesktop ? "100px 0px"
  : props.$isTablet ? "48px"
  : "50px 0"};

  gap: ${(props)=> props.$isDesktop ? "100px": "50px"};
```

### 스크린샷 (선택)

https://github.com/user-attachments/assets/639740af-8557-4295-ac25-76e87fe98803


