### PR TITLE
📝 docs: 기획단 페이지 데이터 1차 수정

### DIFF
--- a/src/data/profileData.jsx
+++ b/src/data/profileData.jsx
@@ -1,15 +1,43 @@
 const mediaUrl = import.meta.env.VITE_MEDIA_URL;
-const sampleImage = `${mediaUrl}About/about_sample.jpg`;
+const sampleImage = `${mediaUrl}Promotion/emptyImage.png`;
 
 export const studentCommitteeProfiles = [
-	{ id: 1, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" },
-	{ id: 2, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" },
-	{ id: 3, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" },
-	{ id: 4, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" },
-	{ id: 5, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" },
-	{ id: 6, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" },
-	{ id: 7, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" },
-	{ id: 8, name: "김OO", role: "PM", image: sampleImage, description: "상세 설명" }
+	{ id: 1, name: "류용현", role: "단장", image: sampleImage, description: "동국청년불자회 회장" },
+	{ id: 2, name: "최윤정", role: "부단장", image: sampleImage, description: "다붓다붓 회장" },
+
+	{ id: 3, name: "박수영", role: "기획국장", image: sampleImage, description: "진선미 회장" },
+	{ id: 4, name: "김민수", role: "기획국원", image: sampleImage, description: "템플애플 부회장" },
+	{ id: 5, name: "류아라", role: "기획국원", image: sampleImage, description: "동불 부회장" },
+	{ id: 6, name: "문정민", role: "기획국원", image: sampleImage, description: "템플애플 회장" },
+	{ id: 7, name: "신민경", role: "기획국원", image: sampleImage, description: "야단법석 부회장" },
+	{ id: 8, name: "이현나", role: "기획국원", image: sampleImage, description: "불사대 회장" },
+	{ id: 9, name: "최정환", role: "기획국원", image: sampleImage, description: "나를 찾아가는 여행 부회장" },
+	{ id: 10, name: "최지원", role: "기획국원", image: sampleImage, description: "가람수호 회장" },
+	{ id: 11, name: "전희재", role: "기획국원", image: sampleImage, description: "캠폴스테이 부회장" },
+
+	{ id: 12, name: "황진경", role: "홍보국장", image: sampleImage, description: "퓨처핸접 부회장" },
+	{ id: 13, name: "강준혁", role: "홍보국원", image: sampleImage, description: "공양미 300석 부회장" },
+	{ id: 14, name: "김민수", role: "홍보국원", image: sampleImage, description: "진선미 부회장" },
+	{ id: 15, name: "김수민", role: "홍보국원", image: sampleImage, description: "나를 찾아가는 여행 회장" },
+	{ id: 16, name: "김준범", role: "홍보국원", image: sampleImage, description: "자연과 함께 회장" },
+	{ id: 17, name: "백희수", role: "홍보국원", image: sampleImage, description: "자연과 함께 부회장" },
+	{ id: 18, name: "양석우", role: "홍보국원", image: sampleImage, description: "다붓다붓 부회장" },
+	{ id: 19, name: "이승협", role: "홍보국원", image: sampleImage, description: "공양미 300석 회장" },
+
+	{ id: 20, name: "정주은", role: "사무국장", image: sampleImage, description: "동국청년불자회 부회장" },
+	{ id: 21, name: "김세연", role: "사무국원", image: sampleImage, description: "부따이 부회장" },
+	{ id: 22, name: "박제민", role: "사무국원", image: sampleImage, description: "캠폴스테이 회장" },
+	{ id: 23, name: "송진형", role: "사무국원", image: sampleImage, description: "약사여래 부회장" },
+	{ id: 24, name: "장재원", role: "사무국원", image: sampleImage, description: "퓨처핸접 회장" },
+	{ id: 25, name: "한서연", role: "사무국원", image: sampleImage, description: "약사여래 회장" },
+	{ id: 26, name: "한수연", role: "사무국원", image: sampleImage, description: "불사대 부회장" },
+
+	{ id: 27, name: "박누리", role: "총무국장", image: sampleImage, description: "부따이 회장" },
+	{ id: 28, name: "김주하", role: "총무국원", image: sampleImage, description: "불법단체 부회장" },
+	{ id: 29, name: "박헌수", role: "총무국원", image: sampleImage, description: "야단법석 회장" },
+	{ id: 30, name: "조원준", role: "총무국원", image: sampleImage, description: "불법단체 회장" },
+	{ id: 31, name: "정현도", role: "총무국원", image: sampleImage, description: "동불 회장" },
+	{ id: 32, name: "황정민", role: "총무국원", image: sampleImage, description: "가람수호 부회장" }
 ];
   
   export const youngCamperProfiles = [

--- a/src/pages/About/style.jsx
+++ b/src/pages/About/style.jsx
@@ -155,13 +155,13 @@ export const ProfileCard = styled.div`
 		display: none; /* 기본적으로 숨김 */
 		position: absolute; /* 오버레이 효과를 위해 */
 		font-family: "MonRegular";
-		color: #fff; /* 텍스트 색상 조정 */
-		font-size: 24px;
+		color: #4A5E6D; /* 텍스트 색상 조정 */
+		text-align: right;
+		font-size: 20px;
 		padding: 28px 32px;
 		bottom: 105px;
 		right: 0;
 		z-index: 2;
-		border-radius: 10px;
 	}
 
 	&:hover {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #104

## 📝작업 내용

> 기획단 페이지 데이터를 1차 수정하였습니다.
1. 기본 이미지를 동아리 페이지와 동일하게 설정하였습니다.
2. 전달 받은 학생기획위원단 명단을 토대로 데이터를 수정하였습니다.
3. 상세설명 폰트 색상을 피그마대로 변경하였습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/9f805a49-1ac1-4de2-9a8a-a9c59c745213)
