### PR TITLE
💄 네브바 반응형 구현 및 코드 리팩토링

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ const Wrapper = styled.div`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  margin-top: ${(props) => (props.$isDesktop ? "73px" : "")};
+  margin-top: ${(props) => (props.$isDesktop ? "73px" : "52px")};
 `;
 
 const Layout = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import "./lib/lang/i18n";
 import { RecoilRoot, useRecoilState } from "recoil";
 import { languageState } from "./context/recoil/languageState";
 import { useTranslation } from "react-i18next";
+import useMediaQueries from "./hooks/useMediaQueries";
 
 const BackGroundColor = styled.div`
   width: 100vw;
@@ -29,11 +30,13 @@ const Wrapper = styled.div`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  margin-top: ${(props) => (props.$isDesktop ? "73px" : "")};
 `;
 
 const Layout = () => {
   const [language, setLanguage] = useRecoilState(languageState);
   const { i18n } = useTranslation();
+  const { isDesktop } = useMediaQueries();
 
   useEffect(() => {
     const savedLanguage = localStorage.getItem("language");
@@ -46,7 +49,7 @@ const Layout = () => {
   return (
     <BackGroundColor>
       <Nav />
-      <Wrapper>
+      <Wrapper $isDesktop={isDesktop}>
         <Outlet /> {/* pages의 페이지가 적용 */}
       </Wrapper>
       <Footer />

--- a/src/layouts/nav/DesktopNav.jsx
+++ b/src/layouts/nav/DesktopNav.jsx
@@ -1,0 +1,51 @@
+// DesktopNav.js
+import React from "react";
+import { useTranslation } from "react-i18next";
+import * as S from "./style";
+import useMediaQueries from "../../hooks/useMediaQueries";
+
+const DesktopNav = ({ logoSrc, isEnglish, handleToggle }) => {
+  const { t } = useTranslation();
+  const { isMobile, isTablet, isDesktop } = useMediaQueries();
+
+  return (
+    <S.Wrapper $isDesktop={isDesktop}>
+      <S.Container $isDesktop={isDesktop}>
+        <S.StyledLink $isTablet={isTablet} to={"/"}>
+          <S.Logo
+            $isDesktop={true}
+            $isEnglish={isEnglish}
+            src={logoSrc}
+            alt="Logo"
+          />
+        </S.StyledLink>
+        {[
+          "Intro",
+          "notification",
+          "promotion",
+          "performance",
+          "location",
+          "review",
+          "FAQ",
+          "about",
+        ].map((path, index) => (
+          <S.StyledLink $isDesktop={isDesktop} key={index} to={`/${path}`}>
+            {t(`nav.${path}`)}
+          </S.StyledLink>
+        ))}
+        <S.LangToggleWrapper>
+          <S.CheckBox
+            type="checkbox"
+            checked={isEnglish}
+            onChange={handleToggle}
+          />
+          <S.LangSlider>
+            <S.ToggleCircle />
+          </S.LangSlider>
+        </S.LangToggleWrapper>
+      </S.Container>
+    </S.Wrapper>
+  );
+};
+
+export default DesktopNav;

--- a/src/layouts/nav/MobileNav.jsx
+++ b/src/layouts/nav/MobileNav.jsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import * as S from "./style";
+import useMediaQueries from "../../hooks/useMediaQueries";
+
+const MobileNav = ({
+  logoSrc,
+  isEnglish,
+  handleToggle,
+  modalOpen,
+  setModalOpen,
+}) => {
+  const { t } = useTranslation();
+  const { isMobile, isTablet, isDesktop } = useMediaQueries();
+  const mediaUrl = import.meta.env.VITE_MEDIA_URL;
+
+  return (
+    <S.Wrapper $isDesktop={isDesktop}>
+      <S.Container $isDesktop={isDesktop}>
+        {/* 네비게이션 바 */}
+        <S.NavBar>
+          <S.TopNav>
+            <S.StyledLink to={"/"}>
+              <S.Logo
+                $isDesktop={false}
+                $isEnglish={isEnglish}
+                src={logoSrc}
+                alt="Logo"
+              />
+            </S.StyledLink>
+
+            <S.Menubar
+              src={`${mediaUrl}Nav/sideNav.png`}
+              onClick={() => {
+                setModalOpen(true);
+              }}
+              alt="메뉴바"
+            />
+          </S.TopNav>
+        </S.NavBar>
+
+        {/* 사이드 내비게이션 */}
+        {modalOpen && (
+          <S.SideNav>
+            <S.NavMobile>
+              <S.Header $isMobile={isMobile}>
+                <S.HeaderContent>
+                  <S.MenubarOpened
+                    src={`${mediaUrl}Nav/re_sideNav.png`}
+                    onClick={() => setModalOpen(false)}
+                  />
+                  <S.LogoWrapper>
+                    <S.StyledLink to={"/"} onClick={() => setModalOpen(false)}>
+                      <S.Logo
+                        $isDesktop={false}
+                        $isEnglish={isEnglish}
+                        src={logoSrc}
+                        alt="Logo"
+                      />
+                    </S.StyledLink>
+                  </S.LogoWrapper>
+                  <S.ModalCloseBtn
+                    src={`${mediaUrl}Nav/exit.png`}
+                    onClick={() => setModalOpen(false)}
+                  />
+                </S.HeaderContent>
+              </S.Header>
+              <S.SideNavLinks>
+                <S.SideNavSet>
+                  {[
+                    "Intro",
+                    "notification",
+                    "promotion",
+                    "performance",
+                    "location",
+                    "review",
+                    "FAQ",
+                    "about",
+                  ].map((path, index) => (
+                    <S.SideNavLink key={index}>
+                      <S.StyledLink
+                        $isTablet={isTablet}
+                        to={`/${path}`}
+                        onClick={() => setModalOpen(false)}
+                      >
+                        {/* 양 옆에 이미지 추가 */}
+                        {path === "promotion" ? (
+                          <>
+                            <S.NavIcon
+                              src={`${mediaUrl}Nav/clubIcon.png`}
+                              alt="Icon Left"
+                            />
+                            {t(`nav.${path}`)}
+                            <S.NavIcon
+                              src={`${mediaUrl}Nav/clubIcon.png`}
+                              alt="Icon Right"
+                            />
+                          </>
+                        ) : (
+                          t(`nav.${path}`)
+                        )}
+                      </S.StyledLink>
+                    </S.SideNavLink>
+                  ))}
+                </S.SideNavSet>
+
+                <S.SideNavEtc>
+                  <S.SideNavLang>
+                    <S.SideNavLangBtn>
+                      <S.SideNavLangText onClick={() => handleToggle(false)}>
+                        한국어
+                      </S.SideNavLangText>
+                      <S.SideNavLangText onClick={() => handleToggle(true)}>
+                        ENG
+                      </S.SideNavLangText>
+                    </S.SideNavLangBtn>
+                  </S.SideNavLang>
+                  <S.SideNavSNS>
+                    <S.SideNavIconContainer>
+                      <a
+                        href="https://www.instagram.com/youngcamp_dgu"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <S.SideNavSnsIcon
+                          src={`${mediaUrl}Nav/Instagram.png`}
+                        />
+                      </a>
+                      <a
+                        href="https://www.youtube.com/@youngcamp_dgu"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <S.SideNavSnsIcon src={`${mediaUrl}Nav/Youtube.png`} />
+                      </a>
+                    </S.SideNavIconContainer>
+                  </S.SideNavSNS>
+                </S.SideNavEtc>
+              </S.SideNavLinks>
+            </S.NavMobile>
+          </S.SideNav>
+        )}
+      </S.Container>
+    </S.Wrapper>
+  );
+};
+
+export default MobileNav;

--- a/src/layouts/nav/Nav.jsx
+++ b/src/layouts/nav/Nav.jsx
@@ -1,236 +1,46 @@
-import { useState, useEffect } from "react";
+// Nav.js
+import React, { useState } from "react";
 import useMediaQueries from "../../hooks/useMediaQueries";
-import * as S from "./style";
-import { useTranslation } from "react-i18next";
-import i18n from "../../lib/lang/i18n";
 import { useRecoilState } from "recoil";
 import { languageState } from "../../context/recoil/languageState";
+import i18n from "../../lib/lang/i18n";
+import DesktopNav from "./DesktopNav";
+import MobileNav from "./MobileNav";
 
 const Nav = () => {
   const { isMobile, isTablet, isDesktop } = useMediaQueries();
   const [lang, setLang] = useRecoilState(languageState);
-  const isChecked = lang === "en";
+  const isEnglish = lang === "en";
 
-  const { t } = useTranslation();
   const [modalOpen, setModalOpen] = useState(false);
-
   const mediaUrl = import.meta.env.VITE_MEDIA_URL;
 
   const handleToggle = () => {
-    const newLang = isChecked ? "ko" : "en"; // 토글 상태에 따라 언어 결정
-    setLang(newLang); // Recoil 상태 업데이트
+    const newLang = isEnglish ? "ko" : "en";
+    setLang(newLang);
     i18n.changeLanguage(newLang);
     localStorage.setItem("language", newLang);
   };
 
+  const logoSrc = `${mediaUrl}Nav/Logo_${isEnglish ? "en" : "kr"}.png`;
+
   return (
     <>
       {isDesktop && (
-        <S.Wrapper>
-          <S.Container>
-            <S.FlexContainer>
-              {/* 로고 */}
-              <S.StyledLink to={"/"}>
-                {isChecked ? (
-                  <S.LogoEn src={`${mediaUrl}Nav/Logo_en.png`} alt="Logo_en" />
-                ) : (
-                  <S.LogoKr src={`${mediaUrl}Nav/Logo_kr.png`} alt="Logo_kr" />
-                )}
-              </S.StyledLink>
-
-              {/* 영캠프 소개 */}
-              <S.StyledLink to={"/Intro"}>{t(`nav.intro`)}</S.StyledLink>
-
-              {/* 공지 */}
-              <S.StyledLink to={"/notification"}>
-                {t(`nav.notification`)}
-              </S.StyledLink>
-
-              {/* 동아리 */}
-              <S.StyledLink to={"/promotion"}>{t(`nav.club`)}</S.StyledLink>
-
-              {/* 공연 일정 */}
-              <S.StyledLink to={"/performance"}>
-                {t(`nav.performance`)}
-              </S.StyledLink>
-
-              {/* 장소 */}
-              <S.StyledLink to={"/location"}>{t(`nav.location`)}</S.StyledLink>
-
-              {/* 후기 */}
-              <S.StyledLink to={"/review"}>{t(`nav.review`)}</S.StyledLink>
-
-              {/* FAQ */}
-              <S.StyledLink to={"/FAQ"}>{t(`nav.faq`)}</S.StyledLink>
-
-              {/* 기획단 */}
-              <S.StyledLink to={"/about"}>{t(`nav.about`)}</S.StyledLink>
-              <S.LangToggleWrapper>
-                <S.CheckBox
-                  type="checkbox"
-                  checked={isChecked}
-                  onChange={handleToggle} // 언어 변경 핸들러
-                />
-                <S.LangSlider>
-                  <S.ToggleCircle />
-                </S.LangSlider>
-              </S.LangToggleWrapper>
-            </S.FlexContainer>
-          </S.Container>
-        </S.Wrapper>
+        <DesktopNav
+          logoSrc={logoSrc}
+          isEnglish={isEnglish}
+          handleToggle={handleToggle}
+        />
       )}
-      {isTablet && <S.Wrapper>{/* Tablet view 관련 내용 생략 */}</S.Wrapper>}
-      {isMobile && (
-        <S.Wrapper>
-          <S.Container>
-            <S.FlexContainer>
-              {modalOpen && (
-                <S.SideNav>
-                  <S.NavMobile>
-                    <S.Header>
-                      <S.HeaderContent>
-                        <S.MenubarOpened
-                          menubar={`${mediaUrl}Nav/Menubar.png`}
-                          onClick={() => setModalOpen(false)}
-                        />
-                        <S.LogoWrapper>
-                          <S.StyledLink
-                            to={"/"}
-                            onClick={() => setModalOpen(false)}
-                          >
-                            {isChecked ? (
-                              <S.LogoEn
-                                src={`${mediaUrl}Nav/Logo_en.png`}
-                                alt="Logo_en"
-                              />
-                            ) : (
-                              <S.LogoKr
-                                src={`${mediaUrl}Nav/Logo_kr.png`}
-                                alt="Logo_kr"
-                              />
-                            )}
-                          </S.StyledLink>
-                        </S.LogoWrapper>
-                        <S.ModalCloseBtn
-                          closeicon={`${mediaUrl}Nav/CloseIcon.png`}
-                          onClick={() => setModalOpen(false)}
-                        />
-                      </S.HeaderContent>
-                    </S.Header>
-                    <S.SideNavLinks>
-                      <S.SideNavSet>
-                        <S.SideNavLink>
-                          <S.StyledLink
-                            to={"/notification"}
-                            onClick={() => setModalOpen(false)}
-                          >
-                            {t("nav.notification")}
-                          </S.StyledLink>
-                        </S.SideNavLink>
-                        <S.SideNavLink>
-                          <S.StyledLink
-                            to={"/promotion"}
-                            onClick={() => setModalOpen(false)}
-                          >
-                            <img
-                              src={`${mediaUrl}Nav/SideNav.png`}
-                              width={"44px"}
-                              height={"44px"}
-                            />
-                            {t("nav.club")}
-                          </S.StyledLink>
-                        </S.SideNavLink>
-                        <S.SideNavLink>
-                          <S.StyledLink
-                            to={"/location"}
-                            onClick={() => setModalOpen(false)}
-                          >
-                            {t("nav.location")}
-                          </S.StyledLink>
-                        </S.SideNavLink>
-                        <S.SideNavLink>
-                          <S.StyledLink
-                            to={"/review"}
-                            onClick={() => setModalOpen(false)}
-                          >
-                            {t("nav.review")}
-                          </S.StyledLink>
-                        </S.SideNavLink>
-                        <S.SideNavLink>
-                          <S.StyledLink
-                            to={"/FAQ"}
-                            onClick={() => setModalOpen(false)}
-                          >
-                            {t("nav.faq")}
-                          </S.StyledLink>
-                        </S.SideNavLink>
-                        <S.SideNavLink>
-                          <S.StyledLink
-                            to={"/about"}
-                            onClick={() => setModalOpen(false)}
-                          >
-                            {t("nav.about")}
-                          </S.StyledLink>
-                        </S.SideNavLink>
-                      </S.SideNavSet>
-                    </S.SideNavLinks>
-                    <S.SideNavEtc>
-                      <S.SideNavLang>
-                        <S.SideNavLangBtn>
-                          <S.SideNavLangText
-                            onClick={() => handleToggle(false)}
-                          >
-                            한국어
-                          </S.SideNavLangText>
-                          <S.SideNavLangText onClick={() => handleToggle(true)}>
-                            ENG
-                          </S.SideNavLangText>
-                        </S.SideNavLangBtn>
-                      </S.SideNavLang>
-                      <S.SideNavSNS>
-                        <S.SideNavIconContainer>
-                          <a
-                            href="https://www.instagram.com/youngcamp_dgu"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <S.SideNavSnsIcon
-                              icon={`${mediaUrl}Nav/Instagram.png`}
-                            />
-                          </a>
-                          <a
-                            href="https://www.youtube.com/@youngcamp_dgu"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <S.SideNavSnsIcon
-                              icon={`${mediaUrl}Nav/Youtube.png`}
-                            />
-                          </a>
-                        </S.SideNavIconContainer>
-                      </S.SideNavSNS>
-                    </S.SideNavEtc>
-                  </S.NavMobile>
-                </S.SideNav>
-              )}
-              <S.StyledLink to={"/"}>
-                {isChecked ? (
-                  <S.LogoEn src={`${mediaUrl}Nav/Logo_en.png`} alt="Logo_en" />
-                ) : (
-                  <S.LogoKr src={`${mediaUrl}Nav/Logo_kr.png`} alt="Logo_kr" />
-                )}
-              </S.StyledLink>
-              <S.MenubarContainer>
-                <S.MenubarWrapper>
-                  <S.Menubar
-                    menubar={`${mediaUrl}Nav/Menubar.png`}
-                    onClick={() => setModalOpen(true)}
-                  />
-                </S.MenubarWrapper>
-              </S.MenubarContainer>
-            </S.FlexContainer>
-          </S.Container>
-        </S.Wrapper>
+      {(isTablet || isMobile) && (
+        <MobileNav
+          logoSrc={logoSrc}
+          isEnglish={isEnglish}
+          handleToggle={handleToggle}
+          modalOpen={modalOpen}
+          setModalOpen={setModalOpen}
+        />
       )}
     </>
   );

--- a/src/layouts/nav/Nav.jsx
+++ b/src/layouts/nav/Nav.jsx
@@ -1,6 +1,4 @@
-import { useState } from "react";
-import logo_kr from "../../assets/images/Nav/Logo_kr.png";
-import logo_en from "../../assets/images/Nav/Logo_en.png";
+import { useState, useEffect } from "react";
 import useMediaQueries from "../../hooks/useMediaQueries";
 import * as S from "./style";
 import { useTranslation } from "react-i18next";
@@ -16,14 +14,14 @@ const Nav = () => {
   const { t } = useTranslation();
   const [modalOpen, setModalOpen] = useState(false);
 
+  const mediaUrl = import.meta.env.VITE_MEDIA_URL;
+
   const handleToggle = () => {
     const newLang = isChecked ? "ko" : "en"; // 토글 상태에 따라 언어 결정
     setLang(newLang); // Recoil 상태 업데이트
     i18n.changeLanguage(newLang);
+    localStorage.setItem("language", newLang);
   };
-
-  //이미지
-  const mediaUrl = import.meta.env.VITE_MEDIA_URL;
 
   return (
     <>
@@ -34,9 +32,9 @@ const Nav = () => {
               {/* 로고 */}
               <S.StyledLink to={"/"}>
                 {isChecked ? (
-                  <S.LogoEn src={logo_en} alt="Logo_en" />
+                  <S.LogoEn src={`${mediaUrl}Nav/Logo_en.png`} alt="Logo_en" />
                 ) : (
-                  <S.LogoKr src={logo_kr} alt="Logo_kr" />
+                  <S.LogoKr src={`${mediaUrl}Nav/Logo_kr.png`} alt="Logo_kr" />
                 )}
               </S.StyledLink>
 
@@ -92,7 +90,7 @@ const Nav = () => {
                     <S.Header>
                       <S.HeaderContent>
                         <S.MenubarOpened
-                          menubar={menubar}
+                          menubar={`${mediaUrl}Nav/Menubar.png`}
                           onClick={() => setModalOpen(false)}
                         />
                         <S.LogoWrapper>
@@ -101,14 +99,20 @@ const Nav = () => {
                             onClick={() => setModalOpen(false)}
                           >
                             {isChecked ? (
-                              <S.LogoEn src={logo_en} alt="Logo_en" />
+                              <S.LogoEn
+                                src={`${mediaUrl}Nav/Logo_en.png`}
+                                alt="Logo_en"
+                              />
                             ) : (
-                              <S.LogoKr src={logo_kr} alt="Logo_kr" />
+                              <S.LogoKr
+                                src={`${mediaUrl}Nav/Logo_kr.png`}
+                                alt="Logo_kr"
+                              />
                             )}
                           </S.StyledLink>
                         </S.LogoWrapper>
                         <S.ModalCloseBtn
-                          closeicon={closeicon}
+                          closeicon={`${mediaUrl}Nav/CloseIcon.png`}
                           onClick={() => setModalOpen(false)}
                         />
                       </S.HeaderContent>
@@ -128,7 +132,11 @@ const Nav = () => {
                             to={"/promotion"}
                             onClick={() => setModalOpen(false)}
                           >
-                            <img src={SideNav} width={"44px"} height={"44px"} />
+                            <img
+                              src={`${mediaUrl}Nav/SideNav.png`}
+                              width={"44px"}
+                              height={"44px"}
+                            />
                             {t("nav.club")}
                           </S.StyledLink>
                         </S.SideNavLink>
@@ -186,14 +194,18 @@ const Nav = () => {
                             target="_blank"
                             rel="noopener noreferrer"
                           >
-                            <S.SideNavSnsIcon icon={Instagram} />
+                            <S.SideNavSnsIcon
+                              icon={`${mediaUrl}Nav/Instagram.png`}
+                            />
                           </a>
                           <a
                             href="https://www.youtube.com/@youngcamp_dgu"
                             target="_blank"
                             rel="noopener noreferrer"
                           >
-                            <S.SideNavSnsIcon icon={Youtube} />
+                            <S.SideNavSnsIcon
+                              icon={`${mediaUrl}Nav/Youtube.png`}
+                            />
                           </a>
                         </S.SideNavIconContainer>
                       </S.SideNavSNS>
@@ -203,15 +215,15 @@ const Nav = () => {
               )}
               <S.StyledLink to={"/"}>
                 {isChecked ? (
-                  <S.LogoEn src={logo_en} alt="Logo_en" />
+                  <S.LogoEn src={`${mediaUrl}Nav/Logo_en.png`} alt="Logo_en" />
                 ) : (
-                  <S.LogoKr src={logo_kr} alt="Logo_kr" />
+                  <S.LogoKr src={`${mediaUrl}Nav/Logo_kr.png`} alt="Logo_kr" />
                 )}
               </S.StyledLink>
               <S.MenubarContainer>
                 <S.MenubarWrapper>
                   <S.Menubar
-                    menubar={menubar}
+                    menubar={`${mediaUrl}Nav/Menubar.png`}
                     onClick={() => setModalOpen(true)}
                   />
                 </S.MenubarWrapper>

--- a/src/layouts/nav/style.jsx
+++ b/src/layouts/nav/style.jsx
@@ -2,173 +2,58 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 export const Wrapper = styled.div`
-  @media only screen and (min-width: 1024px) {
-    width: 100%;
-    height: 100%;
-    padding: 19px 20px;
-    overflow: hidden;
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: flex-start;
-    gap: 18px;
-  }
+  padding: ${(props) => (props.$isDesktop ? "5px 168px;" : "12px 20px")};
+  display: flex;
+  gap: 18px;
+  width: 100vw;
+  align-items: center;
+  justify-content: center;
+  height: ${(props) => (props.$isDesktop ? "73px" : "52px")};
 
-  @media only screen and (max-width: 768px) {
-    width: 100%;
-    height: 100%;
-    justify-content: flex-start;
-    align-items: flex-start;
-    display: inline-flex;
-  }
-
-  @media only screen and ((min-width: 769px) and (max-width: 1023px)) {
-  }
+  //상단 고정
+  position: fixed;
+  top: 0;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 99;
 `;
 
 export const Container = styled.div`
-  @media only screen and (min-width: 1024px) {
-    align-self: stretch;
-    padding: 5px 5%;
-    background: white;
-    backdrop-filter: blur(64px);
-    justify-content: center;
-    align-items: center;
-    display: inline-flex;
-  }
-  @media only screen and (max-width: 768px) {
-    /* flex: 1 1 0;
-    align-self: stretch;
-    justify-content: center;
-    align-items: center;
-    display: flex; */
-    width: 100%;
-    height: 100%;
-    background: white;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    display: inline-flex;
-  }
-  @media only screen and ((min-width: 769px) and (max-width: 1023px)) {
-  }
+  flex-direction: ${(props) => (props.$isDesktop ? "row" : "")};
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  align-items: center;
+  max-width: 1440px;
 `;
 
-export const FlexContainer = styled.div`
-  @media only screen and (min-width: 1024px) {
-    flex: 1 1 0;
-    height: 73px;
-    justify-content: space-between;
-    align-items: center;
-    display: flex;
-  }
-  @media only screen and (max-width: 768px) {
-    /* width: 360px; */
-    width: 100vw;
-    align-self: stretch;
-    padding: 12px 20px;
-    justify-content: space-between;
-    align-items: center;
-    display: flex;
-    background-color: white;
-  }
-  @media only screen and ((min-width: 769px) and (max-width: 1023px)) {
-  }
+export const Logo = styled.img`
+  width: ${(props) => (props.$isDesktop ? "123px" : "72px")};
+  height: ${(props) =>
+    props.$isDesktop
+      ? props.$isEnglish
+        ? "60px"
+        : "45px"
+      : props.$isEnglish
+      ? ""
+      : "26px"};
 `;
 
-export const SideNavWrapper = styled.div`
-  @media only screen and (min-width: 1024px) {
-  }
-  @media only screen and (max-width: 768px) {
-    width: 100%;
-    height: 100%;
-    padding-top: 50px;
-    padding-bottom: 50px;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    display: inline-flex;
-    background-color: #0068ff;
-  }
-  @media only screen and ((min-width: 769px) and (max-width: 1023px)) {
-  }
-`;
-
-export const SideNav1111 = styled.div`
-  @media only screen and (min-width: 1024px) {
-  }
-  @media only screen and (max-width: 768px) {
-    width: 100%;
-    height: 50px;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    border-bottom: 2px #fafafa solid;
-    justify-content: center;
-    align-items: center;
-    display: inline-flex;
-
-    /* flex-direction: column; */
-    /* gap: 16px; */
-  }
-  @media only screen and ((min-width: 769px) and (max-width: 1023px)) {
-  }
-`;
-
-export const SideLine = styled.div`
-  width: 100vw;
-  height: 0px;
-  border: 2px #fafafa solid;
-`;
-
-export const LogoKr = styled.img`
-  @media only screen and (min-width: 1024px) {
-    width: 123px;
-    height: 45px;
-  }
-  @media only screen and (max-width: 768px) {
-    width: 72px;
-    height: 26px;
-  }
-  @media only screen and ((min-width: 769px) and (max-width: 1023px)) {
-  }
-`;
-export const LogoEn = styled.img`
-  @media only screen and (min-width: 1024px) {
-    width: 123px;
-    height: 76.13px;
-  }
-  @media only screen and (max-width: 768px) {
-    width: 72px;
-    height: 26px;
-  }
-  @media only screen and ((min-width: 769px) and (max-width: 1023px)) {
-  }
-`;
+export const LogoLink = styled(Link)``;
 
 export const StyledLink = styled(Link)`
-  color: #0a0b0a;
-  font-size: 20px;
-  font-family: "PretendardSemibold";
-  font-weight: 600;
-  line-height: 24px;
-  word-wrap: break-word;
+  color: ${(props) => (props.$isDesktop ? "#0a0b0a;" : "white")};
+  font-size: ${(props) => (props.$isTablet ? "24px" : "20px")};
+  font-family: "MonRegular";
+  font-weight: 400;
+  font-style: normal;
+  line-height: ${(props) => (props.$isDesktop ? "30px" : "32px")};
   text-align: center;
   justify-content: center;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   display: flex;
-  @media only screen and (max-width: 1023px) {
-    felx: 1 1 0;
-    align-self: stretch;
-    text-align: center;
-    color: #fafafa;
-    font-size: 24px;
-    font-family: "MonRegular";
-    font-weight: 400;
-    line-height: 32px;
-    word-wrap: break-word;
-    gap: 12px;
-  }
+  /* letter-spacing: -1.2px; */
 `;
 
 export const LangSlider = styled.span`
@@ -260,270 +145,166 @@ export const LangToggleWrapper = styled.label`
   height: 44px;
 `;
 
-//mobile & tablet
-export const MenubarContainer = styled.div`
-  width: 28px;
-  align-self: stretch;
-  justify-content: center;
+//MobileNav.jsx
+
+export const NavBar = styled.div`
+  width: 100%;
   align-items: center;
-  gap: 20px;
   display: flex;
+  flex-direction: column;
 `;
 
-export const MenubarWrapper = styled.div`
+export const Menubar = styled.img`
   width: 28px;
   height: 28px;
-  position: relative;
-`;
-
-export const Menubar = styled.button`
-  width: 21px;
-  height: 14px;
-  left: 3.5px;
-  top: 7px;
-  position: absolute;
-  background-image: url(${(props) => props.menubar});
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center;
-  border: none;
   cursor: pointer;
 `;
 
-//modal = sidenav
-export const ModalContainer = styled.div`
-  position: fixed;
-  z-index: 1200;
-  top: 0;
-  left: 0;
-  height: 100vh;
-  width: 100vw;
-  background-color: #0068ff;
-  display: inline-flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-`;
+export const LogoWrapper = styled.div``;
 
-export const Modal = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  /* background: #000000; */
-  overflow: hidden;
-  /* border-radius: 8px; */
-  transition: all 400ms ease-in-out 2s;
-  animation: fadeIn 400ms;
-`;
-
-// export const
-
-export const ModalCloseBtn = styled.button`
-  z-index: 1000;
-  right: 25px;
-  top: 15px;
-  width: 21.91px;
-  height: 21.91px;
-  position: absolute;
-  background-image: url(${(props) => props.closeicon});
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center;
-  border: none;
-  cursor: pointer;
-`;
-
-//다시 짜기
-
+// 전체 화면을 가리는 사이드 네비게이션 스타일
 export const SideNav = styled.div`
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
-  z-index: 1200;
   width: 100vw;
   height: 100vh;
-  background-color: #0068ff;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 999;
+  display: flex;
   flex-direction: column;
-  justify-content: flex-start;
   align-items: center;
-  display: inline-flex;
-
-  overflow: hidden;
-  transition: all 400ms ease-in-out 2s;
-  animation: fadeIn 400ms;
+  justify-content: flex-start;
+  transition: opacity 0.3s ease;
 `;
 
+// 사이드 네비게이션 내부 스타일
 export const NavMobile = styled.div`
   width: 100%;
-  height: 100%;
+  background: #0068ff;
+  color: white;
+  display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  display: inline-flex;
 `;
 
-//container 는 위에 중복
-
-export const Header = styled.div`
-  width: 100%;
-  /* height: 100%; */
-  height: 52px;
-  background: white;
-  flex-direction: column;
-  justify-content: center;
+// 상단 네비게이션 스타일
+export const TopNav = styled.div`
+  display: flex;
   align-items: center;
-  display: inline-flex;
-`;
-
-export const HeaderContent = styled.div`
-  width: 100%;
-  height: 100%;
-  padding-left: 20px;
-  padding-right: 20px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  background: white;
   justify-content: space-between;
-  align-items: center;
-  display: inline-flex;
+  width: 100%;
 `;
 
-export const MenubarOpened = styled.button`
-  z-index: 1000;
-  transform: rotate(180deg);
-  transform-origin: 0 0;
-  width: 21px;
-  height: 14px;
-  left: 50px;
-  top: 35px;
-  position: absolute;
+// 헤더 스타일
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background-color: white;
+`;
 
-  background-image: url(${(props) => props.menubar});
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center;
-  border: none;
+// 헤더 내용 스타일
+export const HeaderContent = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: ${(props) => (props.$isMobile ? "52px" : "56px")};
+  justify-content: space-between;
+  padding: 12px 20px;
+`;
+
+// 메뉴바 열기 버튼 스타일
+export const MenubarOpened = styled.img`
   cursor: pointer;
+  width: 28px;
+  height: 28px;
 `;
 
-export const LogoWrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  justify-content: center;
-  align-items: center;
-  gap: 20px;
-  display: inline-flex;
-`;
-
-//sideNav
-
+// 사이드 네비게이션 링크 스타일
 export const SideNavLinks = styled.div`
-  width: 100%;
-  height: 100%;
-  padding-top: 50px;
-  padding-bottom: 50px;
+  flex-grow: 1;
+  display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  display: inline-flex;
+  color: white;
+  /* margin-top: 50px; */
 `;
 
+// 사이드 네비게이션 링크 셋 스타일
 export const SideNavSet = styled.div`
   width: 100%;
-  height: 100%;
+  display: flex;
   flex-direction: column;
-  justify-content: flex-start;
   align-items: center;
-  display: inline-flex;
+  color: white;
 `;
 
+// 사이드 네비게이션 링크 스타일
 export const SideNavLink = styled.div`
   width: 100%;
-  height: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  border-bottom: 2px solid #fafafa;
-  justify-content: center;
-  align-items: center;
-  display: inline-flex;
-  gap: 12px;
-`;
-
-//언어 변경 및 SNS 링크들
-
-export const SideNavEtc = styled.div`
-  width: 100%;
-  height: 100%;
-  padding-top: 25px;
-  padding-bottom: 25px;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  display: inline-flex;
-`;
-
-export const SideNavLang = styled.div`
-  width: 100%;
-  height: 100%;
-  padding-left: 48px;
-  padding-right: 48px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  justify-content: center;
-  align-items: center;
-  gap: 24px;
-  display: inline-flex;
-`;
-
-export const SideNavLangBtn = styled.div`
-  width: 100%;
-  height: 100%;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  display: inline-flex;
-`;
-
-export const SideNavLangText = styled.button`
-  text-align: center;
-  color: #b9ff9c;
-  font-size: 18px;
+  padding: 8px 0px;
+  border-bottom: 2px solid white;
   font-family: "MonRegular";
   font-weight: 400;
-  line-height: 24px;
-  word-wrap: break-word;
+`;
+
+// 사이드 네비게이션 기타 스타일
+export const SideNavEtc = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 25px 0px;
+`;
+
+// 사이드 네비게이션 언어 설정 스타일
+export const SideNavLang = styled.div`
+  /* margin-bottom: 20px; */
+`;
+
+// 사이드 네비게이션 언어 버튼 스타일
+export const SideNavLangBtn = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 12px 48px;
+`;
+
+// 사이드 네비게이션 언어 텍스트 스타일
+export const SideNavLangText = styled.span`
+  margin: 0 10px;
+  cursor: pointer;
+  font-size: 18px;
+  color: #b9ff9c;
   border-bottom: 1px solid #b9ff9c;
 `;
 
+// 사이드 네비게이션 SNS 스타일
 export const SideNavSNS = styled.div`
-  width: 100%;
-  height: 100%;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  gap: 12px;
-  display: inline-flex;
-
-  justify-content: center;
-  align-items: center;
-`;
-
-export const SideNavIconContainer = styled.div`
-  width: 100%;
-  height: 100%;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
 `;
 
-export const SideNavSnsIcon = styled.div`
+// 사이드 네비게이션 SNS 아이콘 컨테이너 스타일
+export const SideNavIconContainer = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+// 사이드 네비게이션 SNS 아이콘 스타일
+export const SideNavSnsIcon = styled.img`
   width: 24px;
   height: 24px;
-  background-image: url(${(props) => props.icon});
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center;
-  border: none;
   cursor: pointer;
+`;
+
+// 사이드 네비게이션 닫기 버튼 스타일
+export const ModalCloseBtn = styled.img`
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+`;
+
+export const NavIcon = styled.img`
+  width: 24px;
+  height: 24px;
 `;

--- a/src/lib/lang/en/translation.json
+++ b/src/lib/lang/en/translation.json
@@ -1,12 +1,12 @@
 {
   "nav": {
-    "intro": "About",
+    "Intro": "About",
     "notification": "News",
-    "club": "Club",
+    "promotion": "Club",
     "performance": "Schedule",
     "location": "Location",
     "review": "Reviews",
-    "faq": "FAQ",
+    "FAQ": "FAQ",
     "about": "Team"
   },
   "notice": {

--- a/src/lib/lang/ko/translation.json
+++ b/src/lib/lang/ko/translation.json
@@ -1,12 +1,12 @@
 {
   "nav": {
-    "intro": "소개",
+    "Intro": "소개",
     "notification": "공지",
-    "club": "동아리",
+    "promotion": "동아리",
     "performance": "공연일정",
     "location": "장소",
     "review": "후기",
-    "faq": "FAQ",
+    "FAQ": "FAQ",
     "about": "기획단"
   },
   "notice": {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #89

## 📝작업 내용

> 네브바 반응형 구현 완료했고 코드 리팩토링하였습니다. 
네브바 상단 고정했습니다. 
모바일, 테블릿 버전에서 메뉴바가 펼쳐질때 뒤배경을 불투명하게 처리했습니다.
소개 페이지 추가했습니다.

### 스크린샷 (선택)
<img width="1063" alt="스크린샷 2024-09-03 오전 5 07 28" src="https://github.com/user-attachments/assets/15dbe2fd-edbb-4dfe-a782-848ce5f2cf90">
<img width="1063" alt="스크린샷 2024-09-03 오전 5 08 30" src="https://github.com/user-attachments/assets/038b3815-96a0-4a53-aea1-3111ffefb5e8">

<img width="1063" alt="스크린샷 2024-09-03 오전 5 07 57" src="https://github.com/user-attachments/assets/65c41cb7-4775-4bcc-9136-11fa6f262f3d">


## 💬리뷰 요구사항(선택)

> 네브바 상단 고정함에 따라 밑 페이지들과 구분하기 위해 약간의 그림자를 넣었는데 괜찮은가용 ?
모바일, 테블릿 버전대로 네브바의 padding값을 하려니 해당 메뉴가 너무 커져서 짤려서 임의로 조정했습니댜. 괜찮은지 봐주세요..! 디자인분들께도 여쭤보겠습니다.
