### PR TITLE
💄 style: 동아리 상세페이지 제목 모바일 패딩 조절 #69

### DIFF
--- a/src/pages/Promotion/style.jsx
+++ b/src/pages/Promotion/style.jsx
@@ -221,7 +221,7 @@ export const ClubImage = styled.div`
 export const Wrapper = styled.div`
   padding: ${(props) =>
     props.$isMobile
-      ? "48px 24px 24px 24px"
+      ? "48px 0px 24px 0px"
       : props.$isTablet
       ? "48px 24px 24px 24px"
       : "36px 0px 48px 0px"};
@@ -245,7 +245,7 @@ export const TextAndButton = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 45px;
+  gap: 24px;
   height: ${(props) => (props.$isDesktop ? "80px" : "45px")};
 `;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #69 

## 📝작업 내용

> 동아리 상세페이지 모바일 버전 제목 부분 양옆 패딩값 조절했습니다!

### 스크린샷 
![image](https://github.com/user-attachments/assets/1f0131f6-a40e-4ab5-800b-b24ae7bf2a07)