### PR TITLE
🚑 feat: 사이드바, 동아리 옆에 있는 그림에 기능을 추가 - 현재 보고 있는 페이지를 알려주는 피드백 기능

### DIFF
--- a/src/layouts/nav/MobileNav.jsx
+++ b/src/layouts/nav/MobileNav.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as S from "./style";
 import useMediaQueries from "../../hooks/useMediaQueries";
+import { useLocation } from 'react-router-dom';
 
 const MobileNav = ({
   logoSrc,
@@ -13,6 +14,8 @@ const MobileNav = ({
   const { t } = useTranslation();
   const { isMobile, isTablet, isDesktop } = useMediaQueries();
   const mediaUrl = import.meta.env.VITE_MEDIA_URL;
+
+  const location = useLocation();
 
   return (
     <S.Wrapper $isDesktop={isDesktop}>
@@ -82,12 +85,9 @@ const MobileNav = ({
                         $isTablet={isTablet}
                         to={`/${path}`}
                         onClick={() => setModalOpen(false)}
-                        // onMouseOver={() => handleMouseOver("date")}
-                        // onMouseOut={() => handleMouseOut("date")}
-                        // ishoveringDate={titleHover.date}
                       >
                         {/* 양 옆에 이미지 추가 */}
-                        {path === "promotion" ? (
+                        {location.pathname === `/${path}` ? (
                           <>
                             <S.NavIcon
                               src={`${mediaUrl}Nav/clubIcon.png`}


### PR DESCRIPTION
## #️⃣연관된 이슈
> 노션에 트러블 슈팅에서의 의견을 보고 추가헀습니다.

## 📝작업 내용
> 모바일 뷰의 사이드 네비에서, 그동안 동아리 탭에만 양쪽으로 그림이 있었는데
 이제는 현재 보고 있는 페이지에만 그림을 추가하여, 현재 보고 있는 페이지에 대한 피드백을 주는 기능을 추가하였습니다.

### 스크린샷 (선택)

![스크린샷 2024-09-06 01 52 22](https://github.com/user-attachments/assets/4640cc8a-bf95-44a2-b201-c860bb9186b9)
