### PR TITLE
🐛 home 영상 자동 확대 

### DIFF
--- a/src/pages/Home/Video.jsx
+++ b/src/pages/Home/Video.jsx
@@ -39,6 +39,7 @@ const Video = () => {
           autoPlay
           loop
           muted
+          playsInline
         />
         <Link to={`https://youtube.com/@youngcamp_dgu?si=varFM5dZcDp2CaaU`}>
           <S.VideoBtn $isTablet={isTablet} $isDesktop={isDesktop}>


### PR DESCRIPTION
## #️⃣연관된 이슈
-

## 📝작업 내용

> 아이폰 환경에서는 home의 영상이 자동 확대 재생되어 막아주는 코드 한줄 추가했습니다.