### PR TITLE
💄 style: 타이틀 영문 텍스트 반응형 고려해 수정, 동아리 슬라이드 속도 수정 #167

### DIFF
--- a/src/lib/lang/en/translation.json
+++ b/src/lib/lang/en/translation.json
@@ -83,8 +83,8 @@
     "location": "Dongguk University, 30 Pildong-ro 1-gil, Jung-gu, Seoul"
   },
   "home": {
-    "title": "who’s our main character",
-    "location": "Jangchung Gymnasium",
+    "title": "who’s our 주인공",
+    "location": "Jangchung Arena",
     "with": "Join with YoungCamp",
     "video": "Going to watch a video",
     "welcome": "Do you want to escape your boring daily life?\n\nCreated jointly by the Dongguk University Buddhist Club,\nWelcome to Young Camp, a special festival that only lasts for one day!",

--- a/src/pages/Home/ClubSlider.jsx
+++ b/src/pages/Home/ClubSlider.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
@@ -9,10 +9,11 @@ import { useTranslation } from "react-i18next";
 
 function ClubSlider() {
   const { isDesktop, isTablet } = useMediaQueries();
+  
   const settings = {
     dots: false,
     infinite: true,
-    speed: 6000,
+    speed: 1700,
     slidesToScroll: 1,
     autoplay: true,
     autoplaySpeed: 2000,
@@ -98,5 +99,6 @@ function ClubSlider() {
     </S.SliderContainer>
   );
 }
+
 
 export default ClubSlider;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #167

## 📝작업 내용
> QA: 동아리 슬라이드 속도 6000 -> 1700ms 수정
> 타이틀: main character 반응형에서 깨지는 이슈가 있어 디자인팀과 협의 후 주인공 한글로 반영하기로 하였습니다!
> 장충체육관의 공식 명칭 반영 Gymnasium -> Arena

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ad0dd4f2-08ac-4089-a390-f8271ed8612a)


https://github.com/user-attachments/assets/9e94162a-3948-4837-81cc-5e487b88fd61


## 💬리뷰 요구사항(선택)
> 참고사항으로, QA 중 동아리 슬라이드 시 다른 페이지로 갔다가 돌아오면 봤던 페이지를 기억하고 다시 그 페이지부터 슬라이드될 수 있도록 가능할지 요청 질의가 있어 해당 부분 추가로 구현해보는 중입니다.!