### PR TITLE
🐛 fix: sidebar가 항상 맨 앞으로 표시될 수 있도록 변경함

### DIFF
--- a/src/layouts/nav/style.jsx
+++ b/src/layouts/nav/style.jsx
@@ -15,7 +15,7 @@ export const Wrapper = styled.div`
   top: 0;
   background-color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  z-index: 99;
+  z-index: 999;
 `;
 
 export const Container = styled.div`
@@ -182,7 +182,7 @@ export const SideNav = styled.div`
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.8);
-  z-index: 999;
+  /* z-index: 999; */
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -238,6 +238,7 @@ export const HeaderContent = styled.div`
   height: ${(props) => (props.$isMobile ? "52px" : "56px")};
   justify-content: space-between;
   padding: 12px 20px;
+  /* z-index: 999; */
 `;
 
 // 메뉴바 열기 버튼 스타일


### PR DESCRIPTION
## #️⃣연관된 이슈
> 동아리 디테일 정보 페이지에서, 상단에 고정된 요소가 사이드바를 가리는 문제가 있었습니다.

## 📝작업 내용
> z-index를 999로 수정하여, 모바일 환경에서 사이드바가 항상 맨 앞으로 표시 될 수 있도록 수정하였습니다.